### PR TITLE
fix(github): auto-connect and sanitize labels for GitHub operations

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1826,6 +1826,11 @@ pub(crate) async fn agent_turn(
     .await
 }
 
+/// Check if a tool name is a GitHub operation tool (requires authentication)
+fn is_github_tool(call_name: &str) -> bool {
+    call_name.starts_with("github_") && call_name != "github_connect"
+}
+
 async fn execute_one_tool(
     call_name: &str,
     call_arguments: serde_json::Value,
@@ -1837,6 +1842,43 @@ async fn execute_one_tool(
         tool: call_name.to_string(),
     });
     let start = Instant::now();
+
+    // ── Auto-connect GitHub before GitHub operations ─────────────────
+    // If calling a GitHub tool (except github_connect itself), ensure authenticated first
+    if is_github_tool(call_name) {
+        if let Some(connect_tool) = find_tool(tools_registry, "github_connect") {
+            tracing::debug!(tool = %call_name, "Auto-checking GitHub connection before operation");
+            let connect_result = connect_tool.execute(serde_json::json!({})).await;
+            match connect_result {
+                Ok(result) if !result.success => {
+                    // Not authenticated - return the connect error (includes OAuth URL)
+                    let duration = start.elapsed();
+                    let error_msg = result.error.unwrap_or_else(|| {
+                        "GitHub is not connected. Please authenticate first.".to_string()
+                    });
+                    observer.record_event(&ObserverEvent::ToolCall {
+                        tool: call_name.to_string(),
+                        duration,
+                        success: false,
+                    });
+                    return Ok(ToolExecutionOutcome {
+                        output: format!("GitHub authentication required: {error_msg}"),
+                        success: false,
+                        error_reason: Some(scrub_credentials(&error_msg)),
+                        duration,
+                    });
+                }
+                Ok(_) => {
+                    // Successfully authenticated, proceed with the actual tool call
+                    tracing::debug!(tool = %call_name, "GitHub connection verified, proceeding with operation");
+                }
+                Err(e) => {
+                    // Error checking connection - still proceed, let the actual tool handle it
+                    tracing::warn!(tool = %call_name, error = %e, "Failed to check GitHub connection, proceeding anyway");
+                }
+            }
+        }
+    }
 
     let Some(tool) = find_tool(tools_registry, call_name) else {
         let reason = format!("Unknown tool: {call_name}");

--- a/src/tools/github_ops.rs
+++ b/src/tools/github_ops.rs
@@ -105,6 +105,39 @@ fn validate_labels(labels: &[String]) -> Result<(), String> {
     Ok(())
 }
 
+/// Sanitizes labels to only include valid type labels and known scope labels.
+/// Removes labels with spaces (like "help wanted") that cause 422 errors.
+fn sanitize_labels(labels: &[String]) -> Vec<String> {
+    // Known valid scope labels that don't contain spaces
+    const VALID_SCOPE_LABELS: &[&str] = &[
+        "provider", "channel", "tool", "gateway", "memory", "runtime", 
+        "config", "ci", "performance", "ui", "api", "database", "deps",
+    ];
+    
+    labels
+        .iter()
+        .filter(|label| {
+            let label_lower = label.to_lowercase();
+            // Keep type labels
+            if VALID_TYPE_LABELS.contains(&label_lower.as_str()) {
+                return true;
+            }
+            // Keep known scope labels
+            if VALID_SCOPE_LABELS.contains(&label_lower.as_str()) {
+                return true;
+            }
+            // Skip labels with spaces (cause 422 errors if not pre-created in repo)
+            if label.contains(' ') {
+                tracing::warn!(label = %label, "Skipping label with space - may not exist in repository");
+                return false;
+            }
+            // Keep other labels that don't have spaces (might work if they exist)
+            true
+        })
+        .cloned()
+        .collect()
+}
+
 /// Validates that PR title follows conventional commit format
 fn validate_pr_title(title: &str) -> Result<(), String> {
     if title.trim().is_empty() {
@@ -592,6 +625,9 @@ impl Tool for GitHubCreateIssueTool {
             });
         }
 
+        // Sanitize labels to remove problematic ones (e.g., "help wanted" with spaces)
+        let labels = sanitize_labels(&labels);
+
         // Resolve owner: explicit args > parsed from repo > stored username
         let owner = if let Some(o) = args["owner"].as_str().filter(|s| !s.is_empty()) {
             o.to_string()
@@ -813,6 +849,9 @@ impl Tool for GitHubCreatePRTool {
                 )),
             });
         }
+
+        // Sanitize labels to remove problematic ones (e.g., "help wanted" with spaces)
+        let labels = sanitize_labels(&labels);
 
         // Resolve owner: explicit args > parsed from repo > stored username
         let owner = if let Some(o) = args["owner"].as_str().filter(|s| !s.is_empty()) {
@@ -1693,6 +1732,9 @@ impl Tool for GitHubCreateIssueWithHashtagsTool {
                 error_hint: Some("Example: '#bug [Bug]: Login returns 500 error' or '#feature [Feature]: Add dark mode'".to_string()),
             });
         }
+
+        // Sanitize labels to remove problematic ones (e.g., with spaces)
+        let labels = sanitize_labels(&labels);
 
         let title = if let Some(t) = args["title"].as_str().filter(|s| !s.is_empty()) {
             t.to_string()


### PR DESCRIPTION
  ## Problem
  1. GitHub tools (github_create_issue, etc.) failed repeatedly when user wasn't authenticated, causing 5+ consecutive failures
  2. Labels with spaces (like 'help wanted') caused 422 errors if not pre-created in the target repository

  ## Solution

  ### Auto-connect GitHub (src/agent/loop_.rs)
  - Add is_github_tool() helper to detect GitHub operation tools
  - Automatically call github_connect before any GitHub tool execution
  - Return clear auth error with OAuth URL if not connected
  - Prevents unnecessary tool call failures and guides user to authenticate

  ### Label sanitization (src/tools/github_ops.rs)
  - Add sanitize_labels() to filter problematic labels
  - Keep valid type labels (bug, feature, etc.) and known scope labels
  - Remove labels with spaces that cause 422 errors (e.g., 'help wanted')
  - Apply sanitization in github_create_issue, github_create_pr, and github_create_issue_with_hashtags

  ## Testing
  - Agent now auto-detects auth requirement before GitHub operations
  - Labels like 'help wanted' are filtered out automatically
  - Valid labels like 'bug', 'performance', 'provider' are preserved

  Fixes: Tool failed 5 consecutive times when creating GitHub issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub operation tools now automatically validate authentication before execution, with clearer error messages when credentials are required.

* **Improvements**
  * Label handling in GitHub issue and pull request creation now automatically sanitizes and filters user-provided labels for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->