### PR TITLE
ci(docker): add path filters to avoid unnecessary builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,14 +4,31 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+    paths:
+      # Only build Docker image when code actually changes
+      - 'src/**'
+      - 'crates/**'
+      - 'benches/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Dockerfile'
+      - '.dockerignore'
+      # Exclude documentation changes
+      - '!**.md'
+      - '!docs/**'
   pull_request:
     branches: [main]
     paths:
-      - 'Dockerfile'
-      - '.github/workflows/docker-publish.yml'
+      # Same filters for PR builds
       - 'src/**'
+      - 'crates/**'
+      - 'benches/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '!**.md'
+      - '!docs/**'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Only trigger Docker build when code actually changes:

- Rust source code (src/, crates/, benches/)
- Dependencies (Cargo.toml, Cargo.lock)
- Docker configuration (Dockerfile, .dockerignore)

Skip build for:

- Documentation changes (*.md, docs/)
- CI workflow updates (docker-publish.yml itself)
- Other non-code files

This saves GitHub Actions minutes and avoids waste builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Optimized Docker publish workflow to trigger selectively—only when source code, dependencies, or Docker configuration changes occur. Documentation changes no longer trigger unnecessary builds, reducing CI/CD overhead and providing faster feedback on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->